### PR TITLE
Add support to persons endpoints.py for with_current_organizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ client.field_values().update(field_value_id: int, value: models.Value)
 client.field_values().delete(field_value_id: int)
 
 # Persons
-client.persons().list(term: Optional[str] = None, with_interaction_dates: Optional[bool] = None, with_interaction_persons: Optional[bool] = None, with_opportunities: Optional[bool] = None, page_size: Optional[int] = None, page_token: Optional[str] = None)
+client.persons().list(term: Optional[str] = None, with_interaction_dates: Optional[bool] = None, with_current_organizations: Optional[bool] = None, with_opportunities: Optional[bool] = None, page_size: Optional[int] = None, page_token: Optional[str] = None)
 client.persons().get(person_id: int, with_interaction_dates: Optional[bool] = None, with_interaction_persons: Optional[bool] = None, with_opportunities: Optional[bool] = None, with_current_organizations: bool = None)
 client.persons().create(first_name: str, last_name: str, emails: List[str], organization_ids: List[int] = [])
 client.persons().update(person_id: int, first_name: Optional[str] = None, last_name: Optional[str] = None, emails: List[str] = [], organization_ids: List[int] = [])

--- a/affinity/client/endpoints.py
+++ b/affinity/client/endpoints.py
@@ -332,7 +332,7 @@ class Persons(Endpoint):
     allowed_request_types = [RequestType.GET, RequestType.LIST, RequestType.CREATE, RequestType.DELETE, RequestType.UPDATE]
 
     # TODO: Impl min&max_{interaction_type}_date query parms
-    def list(self, term: Optional[str] = None, with_interaction_dates: Optional[bool] = None, with_interaction_persons: Optional[bool] = None, with_opportunities: Optional[bool] = None, page_size: Optional[int] = None, page_token: Optional[str] = None):
+    def list(self, term: Optional[str] = None, with_interaction_dates: Optional[bool] = None, with_current_organizations: Optional[bool] = None, with_opportunities: Optional[bool] = None, page_size: Optional[int] = None, page_token: Optional[str] = None):
         query_params = {k: v for k,v in locals().items() if k != "self" and v != None}
         return self._list(query_params=query_params)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
         name='affinity-crm',
-        version='v1.1.2',
+        version='v1.1.3',
         description='Affinity CRM',
         author='Nathan Duncan',
         author_email='natefduncan@gmail.com',

--- a/tests/test_persons.py
+++ b/tests/test_persons.py
@@ -18,12 +18,11 @@ def test_persons_get_with_params(client):
         persons["persons"][0].id,
         with_interaction_dates=True,
         with_opportunities=True,
-        with_interaction_persons=True,
-        with_current_organizations=True
+        with_current_organizations=True,
     )
-
-    assert person.interaction_dates is not None
-    assert person.interactions is not None
+    assert person.current_organization_ids is not None and len(person.current_organization_ids) > 0
+    assert person.interaction_dates is not None and len(person.interaction_dates) > 0
+    assert person.interactions is not None and  len(person.interactions) > 0
     assert isinstance(person, models.Person)
 
 


### PR DESCRIPTION
The tests in test_persons.py have been updated to include checks for the lengths of lists. We've also updated 'affinity-crm' version number to v1.1.3. The 'list' method in endpoints.py has been modified to replace 'with_interaction_persons' parameter with 'with_current_organizations'.