### PR TITLE
Update 'affinity' package and add retry functionality

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytest==7.4.4
 
 marshmallow==3.*
 setuptools~=65.5.0
+tenacity>=8.2.3

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup
 
 setup(
         name='affinity-crm',
-        version='v1.1.5',
+        version='v1.1.6',
         description='Affinity CRM',
         author='Nathan Duncan',
         author_email='natefduncan@gmail.com',
         url="https://github.com/natefduncan/affinity", 
         packages=['affinity', 'affinity.client', 'affinity.common', 'affinity.core'],
-        install_requires=['requests>=2.28.0', "dataclasses_json>=0.6.1"],
+        install_requires=['requests>=2.28.0', "dataclasses_json>=0.6.1", "tenacity>=8.2.3"],
         )
 


### PR DESCRIPTION
Updated 'affinity' package version to 'v1.1.6' and added 'tenacity' package to handle retries in case of request failures in the 'endpoints' module. Specifically, '_get', '_download', and '_list' functions are now utilizing the 'retry' decorator from 'tenacity', adding exponential backoff strategy to handle failed requests.