### PR TITLE
Support Email interactions and update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ client.opportunities().create(name: str, list_id: int, person_ids: List[int] = [
 client.opportunities().update(opportunity_id: int, name: Optional[str], person_ids: List[int] = [], organization_ids: List[int] = [])
 client.opportunities().delete(opportunity_id: int)
 
-# Interactions (Only Meeting type is currently supported)
+# Interactions (Only Meeting and Email types supported currently)
 client.interactions(type: InteractionType).list(start_time: datetime.datetime, end_time: datetime.datetime, person_id: Optional[int] = None, organization_id: Optional[int] = None, page_token: Optional[str] = None)
 
 # Relationship Strength

--- a/affinity/core/models.py
+++ b/affinity/core/models.py
@@ -189,13 +189,15 @@ class PersonFields:
     dropdown_options: list[DropdownOption]
 
 
+@dataclass_json
 @dataclass
 class EmailInteraction:
     date: dt.datetime
     id: int
     subject: str
     type: InteractionType
-    from_: Person = field(metadata=config(field_name="from"))
+    # from_: Person = field(metadata=config(field_name="from"))
+    from_: Person
     to: list[Person] 
     cc: list[Person]
     direction: DirectionType

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
         name='affinity-crm',
-        version='v1.1.7',
+        version='v1.1.8',
         description='Affinity CRM',
         author='Nathan Duncan & Mehmet Oner Yalcin',
         author_email='natefduncan@gmail.com, oneryalcin@gmail.com',


### PR DESCRIPTION
Expanded the types of interactions supported in README.md to include Email. Updated the version in setup.py. A dedicated class and associated handling was added for EmailInteraction. Adjusted the 'from' field in EmailInteraction model to 'from_' to prevent conflict with Python's reserved keyword.