### PR TITLE
Disable Tenacity

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
         name='affinity-crm',
-        version='v1.1.10',
+        version='v1.1.11',
         description='Affinity CRM',
         author='Nathan Duncan & Mehmet Oner Yalcin',
         author_email='natefduncan@gmail.com, oneryalcin@gmail.com',


### PR DESCRIPTION
The commit comments out the tenacity retry methods and related code in 'affinity/client/endpoints.py'. This includes removal of retry strategies for handling HTTP 429 errors and connection errors. The change impacts _get, _download, and _list functions, effectively eliminating their retry capabilities. The error handling in _get function is also modified to include status code in the RequestFailed exception.