### PR TITLE
Update version and retries on rate limit

### DIFF
--- a/affinity/client/endpoints.py
+++ b/affinity/client/endpoints.py
@@ -57,7 +57,8 @@ class Endpoint:
     @backoff.on_exception(
         backoff.expo,
         exception=RateLimitExceeded,
-        max_tries=5,
+        max_tries=10,
+        max_time=50,
         giveup=lambda e: e.response is not None and e.response.status_code != 429,
         logger=logger
     )
@@ -88,7 +89,8 @@ class Endpoint:
     @backoff.on_exception(
         backoff.expo,
         exception=RateLimitExceeded,
-        max_tries=5,
+        max_tries=10,
+        max_time=50,
         giveup=lambda e: e.response is not None and e.response.status_code != 429,
         logger=logger
     )
@@ -114,7 +116,8 @@ class Endpoint:
     @backoff.on_exception(
         backoff.expo,
         exception=RateLimitExceeded,
-        max_tries=5,
+        max_tries=10,
+        max_time=50,
         giveup=lambda e: e.response is not None and e.response.status_code != 429,
         logger=logger
     )
@@ -143,7 +146,8 @@ class Endpoint:
     @backoff.on_exception(
         backoff.expo,
         exception=RateLimitExceeded,
-        max_tries=5,
+        max_tries=10,
+        max_time=50,
         giveup=lambda e: e.response is not None and e.response.status_code != 429,
         logger=logger
     )
@@ -172,7 +176,8 @@ class Endpoint:
     @backoff.on_exception(
         backoff.expo,
         exception=RateLimitExceeded,
-        max_tries=5,
+        max_tries=10,
+        max_time=50,
         giveup=lambda e: e.response is not None and e.response.status_code != 429,
         logger=logger
     )
@@ -201,7 +206,8 @@ class Endpoint:
     @backoff.on_exception(
         backoff.expo,
         exception=RateLimitExceeded,
-        max_tries=5,
+        max_tries=10,
+        max_time=50,
         giveup=lambda e: e.response is not None and e.response.status_code != 429,
         logger=logger
     )
@@ -228,7 +234,8 @@ class Endpoint:
     @backoff.on_exception(
         backoff.expo,
         exception=RateLimitExceeded,
-        max_tries=5,
+        max_tries=10,
+        max_time=50,
         giveup=lambda e: e.response is not None and e.response.status_code != 429,
         logger=logger
     )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
         name='affinity-crm',
-        version='v1.1.14',
+        version='v1.1.15',
         description='Affinity CRM',
         author='Nathan Duncan & Mehmet Oner Yalcin',
         author_email='natefduncan@gmail.com, oneryalcin@gmail.com',


### PR DESCRIPTION
The module version in setup.py has been updated to v1.1.15. Additionally, several methods in endpoints.py now have increased max_tries from 5 to 10 and a new parameter max_time set at 50, improving their resilience to rate limit exceeded exceptions.